### PR TITLE
feat: record http request params

### DIFF
--- a/packages/hook/src/patch/Global.ts
+++ b/packages/hook/src/patch/Global.ts
@@ -1,8 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
 
 import { Patcher, MessageConstants, MessageSender } from 'pandora-metrics';
 import * as util from 'util';

--- a/packages/hook/src/patch/HttpClient.ts
+++ b/packages/hook/src/patch/HttpClient.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 const http = require('http');
 const https = require('https');
 import { Patcher } from 'pandora-metrics';

--- a/packages/hook/src/patch/HttpServer.ts
+++ b/packages/hook/src/patch/HttpServer.ts
@@ -110,8 +110,13 @@ export class HttpServerPatcher extends Patcher {
     return {};
   }
 
-  bufferTransformer(buffer): ParsedUrlQuery {
-    return parseQS(buffer.toString('utf8'));
+  bufferTransformer(buffer): ParsedUrlQuery | string {
+    try {
+      return parseQS(buffer.toString('utf8'));
+    } catch (error) {
+      debug('transform post data error. ', error);
+      return '';
+    }
   }
 
   shimmer(options) {

--- a/packages/hook/src/patch/Mongodb.ts
+++ b/packages/hook/src/patch/Mongodb.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { Patcher } from 'pandora-metrics';
 import { MongodbShimmer } from './shimmers/mongodb/Shimmer';
 

--- a/packages/hook/src/patch/MySQL.ts
+++ b/packages/hook/src/patch/MySQL.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { Patcher } from 'pandora-metrics';
 import { MySQLShimmer } from './shimmers/mysql/Shimmer';
 

--- a/packages/hook/src/patch/MySQL2.ts
+++ b/packages/hook/src/patch/MySQL2.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { MySQLPatcher } from './MySQL';
 
 export class MySQL2Patcher extends MySQLPatcher {

--- a/packages/hook/src/patch/Redis.ts
+++ b/packages/hook/src/patch/Redis.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { Patcher } from 'pandora-metrics';
 const debug = require('debug')('PandoraHook:Redis');
 

--- a/packages/hook/src/patch/shimmers/http-client/Shimmer.ts
+++ b/packages/hook/src/patch/shimmers/http-client/Shimmer.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 const assert = require('assert');
 const debug = require('debug')('PandoraHook:HttpClient:Shimmer');
 import { DEFAULT_HOST, DEFAULT_PORT, HEADER_SPAN_ID, HEADER_TRACE_ID } from '../../../utils/Constants';

--- a/packages/hook/src/patch/shimmers/mongodb/Constants.ts
+++ b/packages/hook/src/patch/shimmers/mongodb/Constants.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 export const DB_OPS = [
   'addUser',
   'authenticate',

--- a/packages/hook/src/patch/shimmers/mongodb/Shimmer.ts
+++ b/packages/hook/src/patch/shimmers/mongodb/Shimmer.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import * as assert from 'assert';
 import { INSTANCE_UNKNOWN } from '../../../utils/Constants';
 import * as is from 'is-type-of';

--- a/packages/hook/src/patch/shimmers/mysql/QueryParser.ts
+++ b/packages/hook/src/patch/shimmers/mysql/QueryParser.ts
@@ -1,9 +1,4 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- * Inspired by node-newrelic
- */
+
 import * as is from 'is-type-of';
 import { StatementMatcher } from './StatementMatcher';
 import { OPERATION_UNKNOWN } from '../../../utils/Constants';

--- a/packages/hook/src/patch/shimmers/mysql/Shimmer.ts
+++ b/packages/hook/src/patch/shimmers/mysql/Shimmer.ts
@@ -1,8 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
 
 import * as is from 'is-type-of';
 import { isLocalhost, hasOwn } from '../../../utils/Utils';

--- a/packages/hook/src/patch/shimmers/mysql/StatementMatcher.ts
+++ b/packages/hook/src/patch/shimmers/mysql/StatementMatcher.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- * Inspired by node-newrelic
- */
 
 const CLEANER = /^\(?(?:([`'"]?)(.*?)\1\.)?([`'"]?)(.*?)\3\)?$/;
 

--- a/packages/hook/src/patch/shimmers/mysql/Utils.ts
+++ b/packages/hook/src/patch/shimmers/mysql/Utils.ts
@@ -1,8 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
 
 export function extractDatabaseChangeFromUse(sql) {
   // The character ranges for this were pulled from

--- a/packages/hook/src/utils/Constants.ts
+++ b/packages/hook/src/utils/Constants.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 export const DEFAULT_HOST = 'localhost';
 export const DEFAULT_PORT = 80;
 export const HEADER_TRACE_ID = 'x-trace-id';

--- a/packages/hook/src/utils/Database.ts
+++ b/packages/hook/src/utils/Database.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2018 Alibaba Group.
- */
-
 import { hasOwn, isLocalhost } from './Utils';
 import { INSTANCE_UNKNOWN } from './Constants';
 import * as os from 'os';

--- a/packages/hook/src/utils/Utils.ts
+++ b/packages/hook/src/utils/Utils.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import * as url from 'url';
 import * as semver from 'semver';
 

--- a/packages/hook/test/fixtures/global/index.ts
+++ b/packages/hook/test/fixtures/global/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 const { GlobalPatcher } = require('../../../src/patch/Global');
 const globalPatcher = new GlobalPatcher();

--- a/packages/hook/test/fixtures/http-client/index.ts
+++ b/packages/hook/test/fixtures/http-client/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 import { HEADER_SPAN_ID, HEADER_TRACE_ID } from '../../../src/utils/Constants';
 import * as assert from 'assert';

--- a/packages/hook/test/fixtures/http-custom-filter/index.ts
+++ b/packages/hook/test/fixtures/http-custom-filter/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 import * as assert from 'assert';
 import * as url from 'url';

--- a/packages/hook/test/fixtures/http-custom-filter/index.ts
+++ b/packages/hook/test/fixtures/http-custom-filter/index.ts
@@ -1,0 +1,48 @@
+/**
+ * @fileOverview
+ * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
+ * @copyright 2017 Alibaba Group.
+ */
+
+import { RunUtil } from '../../RunUtil';
+import * as assert from 'assert';
+import * as url from 'url';
+import { HttpServerPatcher } from '../../../src/patch/HttpServer';
+
+const httpServerPatcher = new HttpServerPatcher({
+  requestFilter: function(req) {
+    const urlParsed = url.parse(req.url, true);
+    return urlParsed.pathname.indexOf('ignore') > -1;
+  }
+});
+
+RunUtil.run(function(done) {
+  httpServerPatcher.run();
+  const http = require('http');
+  const urllib = require('urllib');
+
+  process.on(<any> 'PANDORA_PROCESS_MESSAGE_TRACE', (report: any) => {
+    assert(report.name === 'HTTP-GET:/');
+    assert(report.spans.length === 1);
+
+    done();
+  });
+
+  const server = http.createServer((req, res) => {
+
+    res.end('hello');
+  });
+
+  server.listen(0, () => {
+    const port = server.address().port;
+
+    setTimeout(function() {
+      // should be ignore
+      urllib.request(`http://localhost:${port}/ignore`);
+    }, 500);
+
+    setTimeout(function() {
+      urllib.request(`http://localhost:${port}`);
+    }, 1000);
+  });
+});

--- a/packages/hook/test/fixtures/http-custom-filter/package.json
+++ b/packages/hook/test/fixtures/http-custom-filter/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "http-trace-test",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "urllib": "^2.25.1"
+  }
+}

--- a/packages/hook/test/fixtures/http-custom-transformer/index.ts
+++ b/packages/hook/test/fixtures/http-custom-transformer/index.ts
@@ -1,0 +1,49 @@
+/**
+ * @fileOverview
+ * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
+ * @copyright 2017 Alibaba Group.
+ */
+
+import { RunUtil } from '../../RunUtil';
+import * as assert from 'assert';
+import { HttpServerPatcher } from '../../../src/patch/HttpServer';
+
+const httpServerPatcher = new HttpServerPatcher({
+  recordPostData: true,
+  bufferTransformer: function(buffer) {
+    return buffer.toString('utf8');
+  }
+});
+
+RunUtil.run(function(done) {
+  httpServerPatcher.run();
+  const http = require('http');
+  const urllib = require('urllib');
+
+  process.on(<any> 'PANDORA_PROCESS_MESSAGE_TRACE', (report: any) => {
+    assert(report.name === 'HTTP-POST:/');
+    assert(report.spans.length === 1);
+    const logs = report.spans[0].logs;
+    const fields = logs[0].fields;
+    assert(fields[0].key === 'data');
+    assert(fields[0].value === 'age=100');
+
+    done();
+  });
+
+  const server = http.createServer((req, res) => {
+
+    res.end('hello');
+  });
+
+  server.listen(0, () => {
+    const port = server.address().port;
+
+    urllib.request(`http://localhost:${port}/?name=test`, {
+      method: 'post',
+      data: {
+        age: 100
+      }
+    });
+  });
+});

--- a/packages/hook/test/fixtures/http-custom-transformer/index.ts
+++ b/packages/hook/test/fixtures/http-custom-transformer/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 import * as assert from 'assert';
 import { HttpServerPatcher } from '../../../src/patch/HttpServer';

--- a/packages/hook/test/fixtures/http-custom-transformer/package.json
+++ b/packages/hook/test/fixtures/http-custom-transformer/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "http-trace-test",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "urllib": "^2.25.1"
+  }
+}

--- a/packages/hook/test/fixtures/http-error/index.ts
+++ b/packages/hook/test/fixtures/http-error/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 import * as assert from 'assert';
 // 放在前面，把 http.ClientRequest 先复写

--- a/packages/hook/test/fixtures/http-record-get/index.ts
+++ b/packages/hook/test/fixtures/http-record-get/index.ts
@@ -1,0 +1,44 @@
+/**
+ * @fileOverview
+ * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
+ * @copyright 2017 Alibaba Group.
+ */
+
+import { RunUtil } from '../../RunUtil';
+import * as assert from 'assert';
+import { HttpServerPatcher } from '../../../src/patch/HttpServer';
+
+const httpServerPatcher = new HttpServerPatcher({
+  recordGetParams: true
+});
+
+RunUtil.run(function(done) {
+  httpServerPatcher.run();
+  const http = require('http');
+  const urllib = require('urllib');
+
+  process.on(<any> 'PANDORA_PROCESS_MESSAGE_TRACE', (report: any) => {
+    assert(report.name === 'HTTP-GET:/');
+    assert(report.spans.length === 1);
+    const logs = report.spans[0].logs;
+    const fields = logs[0].fields;
+
+    assert(fields[0].key === 'query');
+    assert(JSON.stringify(fields[0].value) === '{"name":"test"}');
+
+    done();
+  });
+
+  const server = http.createServer((req, res) => {
+
+    res.end('hello');
+  });
+
+  server.listen(0, () => {
+    const port = server.address().port;
+
+    setTimeout(function() {
+      urllib.request(`http://localhost:${port}/?name=test`);
+    }, 1000);
+  });
+});

--- a/packages/hook/test/fixtures/http-record-get/index.ts
+++ b/packages/hook/test/fixtures/http-record-get/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 import * as assert from 'assert';
 import { HttpServerPatcher } from '../../../src/patch/HttpServer';

--- a/packages/hook/test/fixtures/http-record-get/package.json
+++ b/packages/hook/test/fixtures/http-record-get/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "http-trace-test",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "urllib": "^2.25.1"
+  }
+}

--- a/packages/hook/test/fixtures/http-record-post/index.ts
+++ b/packages/hook/test/fixtures/http-record-post/index.ts
@@ -1,0 +1,46 @@
+/**
+ * @fileOverview
+ * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
+ * @copyright 2017 Alibaba Group.
+ */
+
+import { RunUtil } from '../../RunUtil';
+import * as assert from 'assert';
+import { HttpServerPatcher } from '../../../src/patch/HttpServer';
+
+const httpServerPatcher = new HttpServerPatcher({
+  recordPostData: true
+});
+
+RunUtil.run(function(done) {
+  httpServerPatcher.run();
+  const http = require('http');
+  const urllib = require('urllib');
+
+  process.on(<any> 'PANDORA_PROCESS_MESSAGE_TRACE', (report: any) => {
+    assert(report.name === 'HTTP-POST:/');
+    assert(report.spans.length === 1);
+    const logs = report.spans[0].logs;
+    const fields = logs[0].fields;
+    assert(fields[0].key === 'data');
+    assert(JSON.stringify(fields[0].value) === '{"age":"100"}');
+
+    done();
+  });
+
+  const server = http.createServer((req, res) => {
+
+    res.end('hello');
+  });
+
+  server.listen(0, () => {
+    const port = server.address().port;
+
+    urllib.request(`http://localhost:${port}/?name=test`, {
+      method: 'post',
+      data: {
+        age: 100
+      }
+    });
+  });
+});

--- a/packages/hook/test/fixtures/http-record-post/index.ts
+++ b/packages/hook/test/fixtures/http-record-post/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 import * as assert from 'assert';
 import { HttpServerPatcher } from '../../../src/patch/HttpServer';

--- a/packages/hook/test/fixtures/http-record-post/package.json
+++ b/packages/hook/test/fixtures/http-record-post/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "http-trace-test",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "urllib": "^2.25.1"
+  }
+}

--- a/packages/hook/test/fixtures/http-record-query-and-data/index.ts
+++ b/packages/hook/test/fixtures/http-record-query-and-data/index.ts
@@ -1,0 +1,53 @@
+/**
+ * @fileOverview
+ * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
+ * @copyright 2017 Alibaba Group.
+ */
+
+import { RunUtil } from '../../RunUtil';
+import * as assert from 'assert';
+import { HttpServerPatcher } from '../../../src/patch/HttpServer';
+
+const httpServerPatcher = new HttpServerPatcher({
+  recordGetParams: true,
+  recordPostData: true
+});
+
+RunUtil.run(function(done) {
+  httpServerPatcher.run();
+  const http = require('http');
+  const urllib = require('urllib');
+
+  process.on(<any> 'PANDORA_PROCESS_MESSAGE_TRACE', (report: any) => {
+    assert(report.name === 'HTTP-POST:/');
+    assert(report.spans.length === 1);
+    const logs = report.spans[0].logs;
+    assert(logs.length === 2);
+    const getFields = logs[0].fields;
+    const postFields = logs[1].fields;
+    assert(getFields[0].key === 'query');
+    assert(JSON.stringify(getFields[0].value) === '{"name":"test"}');
+    assert(postFields[0].key === 'data');
+    assert(JSON.stringify(postFields[0].value) === '{"age":"100"}');
+
+    done();
+  });
+
+  const server = http.createServer((req, res) => {
+
+    res.end('hello');
+  });
+
+  server.listen(0, () => {
+    const port = server.address().port;
+
+    setTimeout(function() {
+      urllib.request(`http://localhost:${port}/?name=test`, {
+        method: 'post',
+        data: {
+          age: 100
+        }
+      });
+    }, 1000);
+  });
+});

--- a/packages/hook/test/fixtures/http-record-query-and-data/index.ts
+++ b/packages/hook/test/fixtures/http-record-query-and-data/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 import * as assert from 'assert';
 import { HttpServerPatcher } from '../../../src/patch/HttpServer';

--- a/packages/hook/test/fixtures/http-record-query-and-data/package.json
+++ b/packages/hook/test/fixtures/http-record-query-and-data/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "http-trace-test",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "urllib": "^2.25.1"
+  }
+}

--- a/packages/hook/test/fixtures/http-slow/index.ts
+++ b/packages/hook/test/fixtures/http-slow/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 import * as assert from 'assert';
 import * as url from 'url';

--- a/packages/hook/test/fixtures/http-timeout/index.ts
+++ b/packages/hook/test/fixtures/http-timeout/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 import * as assert from 'assert';
 import * as url from 'url';

--- a/packages/hook/test/fixtures/http/index.ts
+++ b/packages/hook/test/fixtures/http/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 import * as assert from 'assert';
 import * as url from 'url';

--- a/packages/hook/test/fixtures/mongodb/index.ts
+++ b/packages/hook/test/fixtures/mongodb/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 import { MongodbPatcher } from '../../../src/patch/Mongodb';
 import * as assert from 'assert';

--- a/packages/hook/test/fixtures/mysql-integrate/index.ts
+++ b/packages/hook/test/fixtures/mysql-integrate/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 const assert = require('assert');
 const nock = require('nock');

--- a/packages/hook/test/fixtures/mysql-no-callback/index.ts
+++ b/packages/hook/test/fixtures/mysql-no-callback/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 const assert = require('assert');
 const { HttpServerPatcher } = require('../../../src/patch/HttpServer');

--- a/packages/hook/test/fixtures/mysql-pool-cluster/index.ts
+++ b/packages/hook/test/fixtures/mysql-pool-cluster/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 const assert = require('assert');
 const { HttpServerPatcher } = require('../../../src/patch/HttpServer');

--- a/packages/hook/test/fixtures/mysql-pool/index.ts
+++ b/packages/hook/test/fixtures/mysql-pool/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 const assert = require('assert');
 const { HttpServerPatcher } = require('../../../src/patch/HttpServer');

--- a/packages/hook/test/fixtures/mysql/index.ts
+++ b/packages/hook/test/fixtures/mysql/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 const assert = require('assert');
 const { HttpServerPatcher } = require('../../../src/patch/HttpServer');

--- a/packages/hook/test/fixtures/mysql2-integrate/index.ts
+++ b/packages/hook/test/fixtures/mysql2-integrate/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 const assert = require('assert');
 const nock = require('nock');

--- a/packages/hook/test/fixtures/mysql2-pool-cluster/index.ts
+++ b/packages/hook/test/fixtures/mysql2-pool-cluster/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 const assert = require('assert');
 const { HttpServerPatcher } = require('../../../src/patch/HttpServer');

--- a/packages/hook/test/fixtures/mysql2-pool/index.ts
+++ b/packages/hook/test/fixtures/mysql2-pool/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 const assert = require('assert');
 const { HttpServerPatcher } = require('../../../src/patch/HttpServer');

--- a/packages/hook/test/fixtures/mysql2-promise/index.ts
+++ b/packages/hook/test/fixtures/mysql2-promise/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 const assert = require('assert');
 const { HttpServerPatcher } = require('../../../src/patch/HttpServer');

--- a/packages/hook/test/fixtures/mysql2/index.ts
+++ b/packages/hook/test/fixtures/mysql2/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 const assert = require('assert');
 const { HttpServerPatcher } = require('../../../src/patch/HttpServer');

--- a/packages/hook/test/fixtures/redis-callback/index.ts
+++ b/packages/hook/test/fixtures/redis-callback/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 const assert = require('assert');
 const { HttpServerPatcher } = require('../../../src/patch/HttpServer');

--- a/packages/hook/test/fixtures/redis-cluster/index.ts
+++ b/packages/hook/test/fixtures/redis-cluster/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 const assert = require('assert');
 const { HttpServerPatcher } = require('../../../src/patch/HttpServer');

--- a/packages/hook/test/fixtures/redis-promise/index.ts
+++ b/packages/hook/test/fixtures/redis-promise/index.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { RunUtil } from '../../RunUtil';
 const assert = require('assert');
 const { HttpServerPatcher } = require('../../../src/patch/HttpServer');

--- a/packages/hook/test/helpers/fake-mysql-server/FakeMySQLServer.ts
+++ b/packages/hook/test/helpers/fake-mysql-server/FakeMySQLServer.ts
@@ -1,8 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
 
 // Copy from mysqljs/mysql test
 

--- a/packages/hook/test/helpers/fake-redis-server/FakeRedisServer.ts
+++ b/packages/hook/test/helpers/fake-redis-server/FakeRedisServer.ts
@@ -1,8 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
 
 // Copy from luin/ioredis test
 

--- a/packages/hook/test/index.test.ts
+++ b/packages/hook/test/index.test.ts
@@ -58,6 +58,26 @@ describe('unit test', () => {
     it('should timeout trace record', done => {
       fork('http-timeout', done);
     });
+
+    it('should record http get params', done => {
+      fork('http-record-get', done);
+    });
+
+    it('should record http post data', done => {
+      fork('http-record-post', done);
+    });
+
+    it('should filter request with custom', done => {
+      fork('http-custom-filter', done);
+    });
+
+    it('should transform post data with custom', done => {
+      fork('http-custom-transformer', done);
+    });
+
+    it('should record http post data and query params', done => {
+      fork('http-record-query-and-data', done);
+    });
   });
 
   describe('http client', () => {

--- a/packages/hook/test/utils.test.ts
+++ b/packages/hook/test/utils.test.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { expect } from 'chai';
 import * as utils from '../src/utils/Utils';
 

--- a/packages/metrics/src/trace/Shimmer.ts
+++ b/packages/metrics/src/trace/Shimmer.ts
@@ -1,7 +1,4 @@
 /**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
  * Fork from othiym23/shimmer, support generator function and async function
  * 待原包更新支持 Generator 和 async 方法后，回归原包
  */

--- a/packages/metrics/src/util/Mutex.ts
+++ b/packages/metrics/src/util/Mutex.ts
@@ -1,8 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
 
 export class Mutex {
 

--- a/packages/metrics/test/unit/endpoint/TraceEndpoint.test.ts
+++ b/packages/metrics/test/unit/endpoint/TraceEndpoint.test.ts
@@ -1,9 +1,3 @@
-/**
- * @fileOverview
- * @author 凌恒 <jiakun.dujk@alibaba-inc.com>
- * @copyright 2017 Alibaba Group.
- */
-
 import { expect } from 'chai';
 import { TraceEndPoint, SKIP_RATE } from '../../../src/';
 


### PR DESCRIPTION
+ add options to record http get(`recordGetParams`)/post(`recordPostData`) data, all default is false.
+ add `requestFilter` option to custom filter, default is all pass.
+ add `bufferTransformer` option to custom post data transformer, default like:
```javascript
require('querystring').parse(buffer.toString('utf8'));
```