### PR TITLE
feat: record http client response data

### DIFF
--- a/packages/hook/src/patch/HttpClient.ts
+++ b/packages/hook/src/patch/HttpClient.ts
@@ -4,9 +4,15 @@ import { Patcher } from 'pandora-metrics';
 import * as semver from 'semver';
 import { HttpClientShimmer } from './shimmers/http-client/Shimmer';
 
+export type bufferTransformer = (buffer) => object | string;
+
 export class HttpClientPatcher extends Patcher {
 
-  constructor(options = {}) {
+  constructor(options: {
+    forceHttps?: boolean,
+    recordResponse?: boolean,
+    bufferTransformer?: bufferTransformer
+  }) {
     super(Object.assign({
       shimmerClass: HttpClientShimmer,
       remoteTracing: true

--- a/packages/hook/test/fixtures/http-client-record-response/index.ts
+++ b/packages/hook/test/fixtures/http-client-record-response/index.ts
@@ -1,0 +1,83 @@
+import { RunUtil } from '../../RunUtil';
+import * as assert from 'assert';
+// 放在前面，把 http.ClientRequest 先复写
+const nock = require('nock');
+import { HttpServerPatcher, HttpClientPatcher } from '../../../src/';
+const httpServerPatcher = new HttpServerPatcher();
+const httpClientPatcher = new HttpClientPatcher({
+  // nock 复写了 https.request 方法，没有像原始一样调用 http.request，所以需要强制复写
+  forceHttps: true,
+  recordResponse: true
+});
+
+RunUtil.run(function(done) {
+  httpServerPatcher.run();
+  httpClientPatcher.run();
+
+  const http = require('http');
+  const https = require('https');
+
+  process.on(<any>'PANDORA_PROCESS_MESSAGE_TRACE', (report: any) => {
+    const spans = report.spans;
+    assert(spans.length === 2);
+    const logs = spans[1].logs;
+    const fields = logs[0].fields;
+    assert(fields[0].key === 'response');
+    assert(fields[0].value === 'Response from TaoBao.');
+
+    done();
+  });
+
+  nock('https://www.taobao.com')
+    .get('/')
+    .reply(200, 'Response from TaoBao.');
+
+  function request(agent, options) {
+
+    return new Promise((resolve, reject) => {
+      const req = agent.request(options, (res) => {
+        let data = '';
+
+        res.on('data', (d) => {
+          data += d;
+        });
+
+        res.on('end', () => {
+          resolve([res, data]);
+        });
+      });
+
+      req.on('error', (e) => {
+        reject(e);
+      });
+
+      req.end();
+    });
+  }
+
+  const server = http.createServer((req, res) => {
+    request(https, {
+      hostname: 'www.taobao.com',
+      path: '/',
+      method: 'GET'
+    }).then((response) => {
+      res.end('ok');
+    });
+  });
+
+  server.listen(0, () => {
+    const port = server.address().port;
+
+    setTimeout(function() {
+      request(http, {
+        hostname: 'localhost',
+        port: port,
+        path: '/',
+        method: 'GET'
+      }).catch((err) => {
+        console.log('err: ', err);
+      });
+    }, 500);
+  });
+});
+

--- a/packages/hook/test/fixtures/http-client-record-response/package.json
+++ b/packages/hook/test/fixtures/http-client-record-response/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "http-client-test",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "urllib": "^2.25.1"
+  }
+}

--- a/packages/hook/test/index.test.ts
+++ b/packages/hook/test/index.test.ts
@@ -92,6 +92,10 @@ describe('unit test', () => {
     it('should urllib work ok', done => {
       fork('urllib', done);
     });
+
+    it('should record response data', done => {
+      fork('http-client-record-response', done);
+    });
   });
 
   describe('mysql', () => {


### PR DESCRIPTION
+ record http client response data(`recordResponse`), default is false.
+ support custom response data format(`bufferTransformer`), default is 
```
buffer.toString('utf8');
```