### PR TITLE
fix: fix http server post data record

### DIFF
--- a/packages/hook/src/patch/shimmers/http-client/Shimmer.ts
+++ b/packages/hook/src/patch/shimmers/http-client/Shimmer.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import { DEFAULT_HOST, DEFAULT_PORT, HEADER_SPAN_ID, HEADER_TRACE_ID } from '../../../utils/Constants';
 import { nodeVersion } from '../../../utils/Utils';
-import { ClientRequest } from 'http';
+import { ClientRequest, ServerResponse } from 'http';
 
 const debug = require('debug')('PandoraHook:HttpClient:Shimmer');
 
@@ -127,7 +127,7 @@ export class HttpClientShimmer {
     shimmer.wrap(request, 'emit', function requestEmitWrapper(emit) {
       const bindRequestEmit = traceManager.bind(emit);
 
-      return function wrappedRequestEmit(this: ClientRequest, event, arg) {
+      return function wrappedRequestEmit(this: ServerResponse, event, arg) {
         if (event === 'error') {
           self.handleError(span, arg);
         } else if (event === 'response') {

--- a/packages/hook/test/fixtures/http-custom-transformer/index.ts
+++ b/packages/hook/test/fixtures/http-custom-transformer/index.ts
@@ -27,7 +27,15 @@ RunUtil.run(function(done) {
 
   const server = http.createServer((req, res) => {
 
-    res.end('hello');
+    const chunks = [];
+
+    req.on('data', (chunk) => {
+      chunks.push(chunk);
+    });
+
+    req.on('end', () => {
+      res.end('hello');
+    });
   });
 
   server.listen(0, () => {

--- a/packages/hook/test/fixtures/http-record-post/index.ts
+++ b/packages/hook/test/fixtures/http-record-post/index.ts
@@ -1,6 +1,6 @@
 import { RunUtil } from '../../RunUtil';
 import * as assert from 'assert';
-import { HttpServerPatcher } from '../../../src/patch/HttpServer';
+import { HttpServerPatcher } from '../../../src/';
 
 const httpServerPatcher = new HttpServerPatcher({
   recordPostData: true
@@ -24,7 +24,15 @@ RunUtil.run(function(done) {
 
   const server = http.createServer((req, res) => {
 
-    res.end('hello');
+    const chunks = [];
+
+    req.on('data', (chunk) => {
+      chunks.push(chunk);
+    });
+
+    req.on('end', () => {
+      res.end('hello');
+    });
   });
 
   server.listen(0, () => {

--- a/packages/hook/test/fixtures/http-record-query-and-data/index.ts
+++ b/packages/hook/test/fixtures/http-record-query-and-data/index.ts
@@ -29,7 +29,15 @@ RunUtil.run(function(done) {
 
   const server = http.createServer((req, res) => {
 
-    res.end('hello');
+    const chunks = [];
+
+    req.on('data', (chunk) => {
+      chunks.push(chunk);
+    });
+
+    req.on('end', () => {
+      res.end('hello');
+    });
   });
 
   server.listen(0, () => {


### PR DESCRIPTION
+ 修复 http server 对 post 请求的记录问题，由于之前提前消费了 `data` 事件的数据，导致后面的 raw-body 等无法获得数据。