### PR TITLE
当 post 请求使用 Request Payload 传参时 ，data 的 parse 不正确。

### DIFF
--- a/packages/hook/src/patch/HttpServer.ts
+++ b/packages/hook/src/patch/HttpServer.ts
@@ -112,11 +112,29 @@ export class HttpServerPatcher extends Patcher {
   }
 
   bufferTransformer(buffer): ParsedUrlQuery | string {
+    const dataStr = buffer.toString('utf8');
+    let data = safeParse(dataStr);
+    if (typeof(data) === 'string') {
+      data = parseQS(dataStr);
+    }
     try {
-      return parseQS(buffer.toString('utf8'));
+      return data;
     } catch (error) {
       debug('transform post data error. ', error);
       return '';
+    }
+
+    /**
+     * TODO move to util
+     * @param str
+     * @returns {any}
+     */
+    function safeParse(str) {
+      try {
+        return JSON.parse(str);
+      } catch (e) {
+        return str;
+      }
     }
   }
 

--- a/packages/hook/test/fixtures/http-record-post/index.ts
+++ b/packages/hook/test/fixtures/http-record-post/index.ts
@@ -17,7 +17,8 @@ RunUtil.run(function(done) {
     const logs = report.spans[0].logs;
     const fields = logs[0].fields;
     assert(fields[0].key === 'data');
-    assert(JSON.stringify(fields[0].value) === '{"age":"100"}');
+    // assert(JSON.stringify(fields[0].value) === '{"age":"100"}');
+    assert.deepEqual(fields[0].value, {age: 100});
 
     done();
   });
@@ -40,6 +41,9 @@ RunUtil.run(function(done) {
 
     urllib.request(`http://localhost:${port}/?name=test`, {
       method: 'post',
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8'
+      },
       data: {
         age: 100
       }


### PR DESCRIPTION
修复BUG：当 post 请求使用 Request Payload 传参（ content-type 为 json） ，data 的 parse 不正确。
