### PR TITLE
Feat/refactor http hook

### DIFF
--- a/packages/hook/src/patch/HttpClient.ts
+++ b/packages/hook/src/patch/HttpClient.ts
@@ -8,7 +8,7 @@ export type bufferTransformer = (buffer) => object | string;
 
 export class HttpClientPatcher extends Patcher {
 
-  constructor(options: {
+  constructor(options?: {
     forceHttps?: boolean,
     recordResponse?: boolean,
     bufferTransformer?: bufferTransformer

--- a/packages/hook/src/patch/HttpServer.ts
+++ b/packages/hook/src/patch/HttpServer.ts
@@ -1,10 +1,10 @@
 'use strict';
 
-import {Patcher, getRandom64} from 'pandora-metrics';
-import {extractPath} from '../utils/Utils';
-import {HEADER_TRACE_ID} from '../utils/Constants';
-import {parse as parseUrl} from 'url';
-import {parse as parseQS, ParsedUrlQuery} from 'querystring';
+import { Patcher, getRandom64 } from 'pandora-metrics';
+import { extractPath } from '../utils/Utils';
+import { HEADER_TRACE_ID } from '../utils/Constants';
+import { parse as parseUrl } from 'url';
+import { parse as parseQS, ParsedUrlQuery } from 'querystring';
 import * as http from 'http';
 
 const debug = require('debug')('PandoraHook:HttpServerPatcher');

--- a/packages/hook/src/patch/shimmers/http-client/Shimmer.ts
+++ b/packages/hook/src/patch/shimmers/http-client/Shimmer.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
-import {DEFAULT_HOST, DEFAULT_PORT, HEADER_SPAN_ID, HEADER_TRACE_ID} from '../../../utils/Constants';
-import {nodeVersion} from '../../../utils/Utils';
-import {ClientRequest} from 'http';
+import { DEFAULT_HOST, DEFAULT_PORT, HEADER_SPAN_ID, HEADER_TRACE_ID } from '../../../utils/Constants';
+import { nodeVersion } from '../../../utils/Utils';
+import { ClientRequest } from 'http';
 
 const debug = require('debug')('PandoraHook:HttpClient:Shimmer');
 
@@ -168,7 +168,7 @@ export class HttpClientShimmer {
       });
       return _request;
     };
-  }
+  };
 
   protected _requestError(res, span) {
 

--- a/packages/metrics/src/domain.ts
+++ b/packages/metrics/src/domain.ts
@@ -177,7 +177,7 @@ export interface SpanData {
   timestamp: number;
   duration: number;
   logs: Array<{
-    timestamp: string;
+    timestamp: number;
     fields: any;
   }>;
   tags: object;


### PR DESCRIPTION
我拓展了 HttpServerPatcher 和 HttpClientPatcher，让这两个 Hook 都能记录 query、data 和 response。
具体实现可见：
https://github.com/kaolalicai/klg-tracer/blob/master/src/patch/HttpServer.ts
https://github.com/kaolalicai/klg-tracer/blob/master/src/patch/shimmers/http-client/Shimmer.ts

拓展的过程有些小麻烦，主要是上述两个组件的代码结构会有不方便拓展的地方，导致我不能简单复写某些方法，表现有：
1 HttpServerPatcher.shimmer 函数过长，如果要替换其中某段逻辑不方便
2 KlgHttpClientShimmer.wrapRequest 是以成员属性的方式定义的，overwrite 后 super.wrapRequest 会有问题。

除了拓展的问题，我在整理代码的时候发现像
```js
shimmer.wrap(req, 'emit', function wrapRequestEmit (emit) {
        const bindRequestEmit = traceManager.bind(emit)
        return function wrappedRequestEmit (this: IncomingMessage, event) {
          if (event === 'data') {
            // do some thing
          }
          return bindRequestEmit.apply(this, arguments)
        }
      })
```
这类的钩子其实可以直接用事件监听来实现， 如下，而且没问题，测试通过
```js
req.once('data', (data) => {
       // do some thing
})
```

针对上述问题，我按照我的想法把 HttpServer 和 KlgHttpClientShimmer 整理了一遍，勉强做个抽象，发了个 PR，供参考。

HttpServer 大致代码结构：
```js
shimmer
    const {tracer, span} = self.initTracerAndSpan(req, res);
    self.wrapRequest(req, res, tracer, span){
      self.recordQuery(req, res, tracer, span);
      self.recordBodyData(req, res, tracer, span);
      // TODO recordResponse
    }
    self.handleResponse(req, res, tracer, span);   // finish tracer and span
```

KlgHttpClientShimmer 大致代码结构：
```js
httpRequestWrapper
      const {tracer, span} = self.initTracerAndSpan(req, res);
      _request.once('error', (res) => {
        self.handleError(span, res);  // set span error
      });
      
      _request.once('response', (res) => {
        self.wrapRequest(_request, res, tracer, span){
          // TODO this.recordQuery(req, tracer, span);
          // TODO this.recordData(req, tracer, span);
          this.recordResponseWrap(req, res, tracer, span);
        }
        self.handleResponse(_request, res, tracer, span); // finish span
      });
```
