### PR TITLE
Feat/http encoding and host

### DIFF
--- a/packages/hook/src/patch/HttpClient.ts
+++ b/packages/hook/src/patch/HttpClient.ts
@@ -2,9 +2,10 @@ const http = require('http');
 const https = require('https');
 import { Patcher } from 'pandora-metrics';
 import * as semver from 'semver';
+import { IncomingMessage } from 'http';
 import { HttpClientShimmer } from './shimmers/http-client/Shimmer';
 
-export type bufferTransformer = (buffer) => object | string;
+export type bufferTransformer = (buffer, res?: IncomingMessage) => object | string;
 
 export class HttpClientPatcher extends Patcher {
 

--- a/packages/hook/src/patch/HttpServer.ts
+++ b/packages/hook/src/patch/HttpServer.ts
@@ -10,7 +10,7 @@ import { IncomingMessage } from 'http';
 
 const debug = require('debug')('Pandora:Hook:HttpServerPatcher');
 
-export type bufferTransformer = (buffer, contentType?: string) => object | string;
+export type bufferTransformer = (buffer, req?: IncomingMessage) => object | string;
 
 export type requestFilter = (req) => boolean;
 
@@ -112,7 +112,7 @@ export class HttpServerPatcher extends Patcher {
     return {};
   }
 
-  bufferTransformer(buffer, contentType?: string): ParsedUrlQuery | string {
+  bufferTransformer(buffer, req?: IncomingMessage): ParsedUrlQuery | string {
     try {
       return parseQS(buffer.toString('utf8'));
     } catch (error) {
@@ -189,8 +189,7 @@ export class HttpServerPatcher extends Patcher {
 
                 if (eventName !== 'aborted' && options.recordPostData && req.method && req.method.toUpperCase() === 'POST') {
                   const transformer = options.bufferTransformer || self.bufferTransformer;
-                  const contentType = req.headers && req.headers['content-type'];
-                  const postData = transformer(chunks, contentType);
+                  const postData = transformer(Buffer.concat(chunks), req);
 
                   span.log({
                     data: postData

--- a/packages/hook/src/patch/HttpServer.ts
+++ b/packages/hook/src/patch/HttpServer.ts
@@ -10,7 +10,7 @@ import { IncomingMessage } from 'http';
 
 const debug = require('debug')('Pandora:Hook:HttpServerPatcher');
 
-export type bufferTransformer = (buffer) => object | string;
+export type bufferTransformer = (buffer, contentType?: string) => object | string;
 
 export type requestFilter = (req) => boolean;
 
@@ -20,7 +20,8 @@ export class HttpServerPatcher extends Patcher {
     recordGetParams?: boolean,
     recordPostData?: boolean,
     bufferTransformer?: bufferTransformer,
-    requestFilter?: requestFilter
+    requestFilter?: requestFilter,
+    recordUrl?: boolean
   }) {
     super(options || {});
 
@@ -111,7 +112,7 @@ export class HttpServerPatcher extends Patcher {
     return {};
   }
 
-  bufferTransformer(buffer): ParsedUrlQuery | string {
+  bufferTransformer(buffer, contentType?: string): ParsedUrlQuery | string {
     try {
       return parseQS(buffer.toString('utf8'));
     } catch (error) {
@@ -145,6 +146,13 @@ export class HttpServerPatcher extends Patcher {
             self._beforeExecute(tracer, req, res);
             const tags = self.buildTags(req);
             const span = self.createSpan(tracer, tags);
+
+            if (options.recordUrl) {
+              // record origin url
+              span.log({
+                originUrl: req.url
+              });
+            }
 
             if (options.recordGetParams) {
               const query = self.processGetParams(req);
@@ -181,7 +189,8 @@ export class HttpServerPatcher extends Patcher {
 
                 if (eventName !== 'aborted' && options.recordPostData && req.method && req.method.toUpperCase() === 'POST') {
                   const transformer = options.bufferTransformer || self.bufferTransformer;
-                  const postData = transformer(chunks);
+                  const contentType = req.headers && req.headers['content-type'];
+                  const postData = transformer(chunks, contentType);
 
                   span.log({
                     data: postData

--- a/packages/hook/src/patch/HttpServer.ts
+++ b/packages/hook/src/patch/HttpServer.ts
@@ -121,6 +121,16 @@ export class HttpServerPatcher extends Patcher {
     }
   }
 
+  getFullUrl(req: IncomingMessage): string {
+    if (!req) return '';
+
+    const secure = (<any>req.connection).encrypted || req.headers['x-forwarded-proto'] === 'https';
+
+    return 'http' + (secure ? 's' : '') + '://' +
+      req.headers.host +
+      req.url;
+  }
+
   shimmer(options) {
     const self = this;
     const traceManager = this.getTraceManager();
@@ -150,7 +160,7 @@ export class HttpServerPatcher extends Patcher {
             if (options.recordUrl) {
               // record origin url
               span.log({
-                originUrl: req.url
+                originUrl: self.getFullUrl(req)
               });
             }
 

--- a/packages/hook/src/patch/shimmers/http-client/Shimmer.ts
+++ b/packages/hook/src/patch/shimmers/http-client/Shimmer.ts
@@ -7,7 +7,7 @@ const debug = require('debug')('PandoraHook:HttpClient:Shimmer');
 
 // TODO: 接受参数，处理或记录请求详情
 
-export type bufferTransformer = (buffer) => object | string;
+export type bufferTransformer = (buffer, encoding?: string) => object | string;
 
 export class HttpClientShimmer {
 
@@ -193,9 +193,9 @@ export class HttpClientShimmer {
 
   protected _finish(res, span) {}
 
-  bufferTransformer(buffer): string {
+  bufferTransformer(buffer, encoding?: string): string {
     try {
-      return buffer.toString('utf8');
+      return buffer.toString(encoding || 'utf8');
     } catch (error) {
       debug('transform response data error. ', error);
       return '';
@@ -220,7 +220,8 @@ export class HttpClientShimmer {
           if (span) {
 
             if (recordResponse) {
-              const response = bufferTransformer(res.__chunks);
+              const encoding = res.headers && res.headers['content-encoding'];
+              const response = bufferTransformer(res.__chunks, encoding);
               span.log({
                 response
               });

--- a/packages/hook/src/patch/shimmers/http-client/Shimmer.ts
+++ b/packages/hook/src/patch/shimmers/http-client/Shimmer.ts
@@ -1,13 +1,13 @@
 import * as assert from 'assert';
 import { DEFAULT_HOST, DEFAULT_PORT, HEADER_SPAN_ID, HEADER_TRACE_ID } from '../../../utils/Constants';
 import { nodeVersion } from '../../../utils/Utils';
-import { ClientRequest, ServerResponse } from 'http';
+import { ClientRequest, ServerResponse, IncomingMessage } from 'http';
 
 const debug = require('debug')('PandoraHook:HttpClient:Shimmer');
 
 // TODO: 接受参数，处理或记录请求详情
 
-export type bufferTransformer = (buffer, encoding?: string) => object | string;
+export type bufferTransformer = (buffer, res?: IncomingMessage) => object | string;
 
 export class HttpClientShimmer {
 
@@ -193,9 +193,9 @@ export class HttpClientShimmer {
 
   protected _finish(res, span) {}
 
-  bufferTransformer(buffer, encoding?: string): string {
+  bufferTransformer(buffer, res?: IncomingMessage): string {
     try {
-      return buffer.toString(encoding || 'utf8');
+      return buffer.toString('utf8');
     } catch (error) {
       debug('transform response data error. ', error);
       return '';
@@ -220,8 +220,7 @@ export class HttpClientShimmer {
           if (span) {
 
             if (recordResponse) {
-              const encoding = res.headers && res.headers['content-encoding'];
-              const response = bufferTransformer(res.__chunks, encoding);
+              const response = bufferTransformer(Buffer.concat(res.__chunks), res);
               span.log({
                 response
               });

--- a/packages/hook/test/fixtures/http-client-record-response/index.ts
+++ b/packages/hook/test/fixtures/http-client-record-response/index.ts
@@ -30,7 +30,9 @@ RunUtil.run(function(done) {
 
   nock('https://www.taobao.com')
     .get('/')
-    .reply(200, 'Response from TaoBao.');
+    .reply(200, new Buffer('Response from TaoBao.', 'utf8'), {
+      'Content-Encoding': 'utf8'
+    });
 
   function request(agent, options) {
 

--- a/packages/hook/test/fixtures/http-client-record-response/index.ts
+++ b/packages/hook/test/fixtures/http-client-record-response/index.ts
@@ -1,5 +1,6 @@
 import { RunUtil } from '../../RunUtil';
 import * as assert from 'assert';
+import { gzipSync, unzipSync } from 'zlib';
 // 放在前面，把 http.ClientRequest 先复写
 const nock = require('nock');
 import { HttpServerPatcher, HttpClientPatcher } from '../../../src/';
@@ -7,7 +8,17 @@ const httpServerPatcher = new HttpServerPatcher();
 const httpClientPatcher = new HttpClientPatcher({
   // nock 复写了 https.request 方法，没有像原始一样调用 http.request，所以需要强制复写
   forceHttps: true,
-  recordResponse: true
+  recordResponse: true,
+  bufferTransformer: (buffer, res) => {
+    const encoding = res.headers['content-encoding'];
+    let data = buffer;
+
+    if (encoding === 'gzip') {
+      data = unzipSync(data);
+    }
+
+    return data.toString('utf8');
+  }
 });
 
 RunUtil.run(function(done) {
@@ -30,8 +41,8 @@ RunUtil.run(function(done) {
 
   nock('https://www.taobao.com')
     .get('/')
-    .reply(200, new Buffer('Response from TaoBao.', 'utf8'), {
-      'Content-Encoding': 'utf8'
+    .reply(200, gzipSync(Buffer.from('Response from TaoBao.')), {
+      'Content-Encoding': 'gzip'
     });
 
   function request(agent, options) {

--- a/packages/hook/test/fixtures/http-custom-transformer/index.ts
+++ b/packages/hook/test/fixtures/http-custom-transformer/index.ts
@@ -4,8 +4,15 @@ import { HttpServerPatcher } from '../../../src/patch/HttpServer';
 
 const httpServerPatcher = new HttpServerPatcher({
   recordPostData: true,
-  bufferTransformer: function(buffer) {
-    return buffer.toString('utf8');
+  bufferTransformer: function(buffer, req) {
+    const type = req.headers['content-type'];
+    let data = buffer.toString('utf8');
+
+    if (type === 'application/x-www-form-urlencoded') {
+      data = `~${data}~`;
+    }
+
+    return data;
   }
 });
 
@@ -20,7 +27,7 @@ RunUtil.run(function(done) {
     const logs = report.spans[0].logs;
     const fields = logs[0].fields;
     assert(fields[0].key === 'data');
-    assert(fields[0].value === 'age=100');
+    assert(fields[0].value === '~age=100~');
 
     done();
   });

--- a/packages/hook/test/fixtures/http-custom-transformer/index.ts
+++ b/packages/hook/test/fixtures/http-custom-transformer/index.ts
@@ -13,7 +13,8 @@ const httpServerPatcher = new HttpServerPatcher({
     }
 
     return data;
-  }
+  },
+  recordUrl: true
 });
 
 RunUtil.run(function(done) {
@@ -25,9 +26,14 @@ RunUtil.run(function(done) {
     assert(report.name === 'HTTP-POST:/');
     assert(report.spans.length === 1);
     const logs = report.spans[0].logs;
-    const fields = logs[0].fields;
-    assert(fields[0].key === 'data');
-    assert(fields[0].value === '~age=100~');
+    const urlLog = logs[0];
+    const paramsLog = logs[1];
+    const urlFields = urlLog.fields;
+    assert(urlFields[0].key === 'originUrl');
+    assert(urlFields[0].value.match(/http:\/\/localhost:\d+\/\?name=test/));
+    const paramsFields = paramsLog.fields;
+    assert(paramsFields[0].key === 'data');
+    assert(paramsFields[0].value === '~age=100~');
 
     done();
   });


### PR DESCRIPTION
+ record origin to log with option `recordUrl` is true.
+ adjust `bufferTransformer` arguments, like: 
```
type bufferTransformer = (buffer, req?: IncomingMessage) => object | string;
```