### PR TITLE
fix: disable http metrics for agent processes

### DIFF
--- a/packages/component-auto-patching/test/Patcher.test.ts
+++ b/packages/component-auto-patching/test/Patcher.test.ts
@@ -4,6 +4,7 @@ import { CURRENT_CONTEXT } from '../src/constants';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { consoleLogger } from 'pandora-dollar';
+import { IPandoraContext } from 'pandora-component-trace/src/domain';
 
 describe('Patcher', () => {
   let cls;
@@ -41,7 +42,7 @@ describe('Patcher', () => {
 
       expect(context.test).to.equal(1);
 
-      cp.currentContext = {
+      cp.currentContext = <IPandoraContext>{
         traceId: '1',
         traceName: '2'
       };


### PR DESCRIPTION
请求成功率的 metric 采集忽略 pandora agent 进程以及 agent worker 进程