### PR TITLE
fix: support data type text and encoding compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - "8"
   - "9"
   - "10"
+  - "12"
 install:
   - npm i
   - npm i codecov

--- a/package.json
+++ b/package.json
@@ -15,27 +15,21 @@
     "vuepress": "^0.14.4"
   },
   "scripts": {
-
     "bootstrap": "rm -f ./packages/.DS*; lerna bootstrap",
     "build": "sh scripts/build.sh",
     "test": "lerna run test --concurrency=1 --stream",
     "cov": "nyc lerna run cov --concurrency=1 --stream",
     "ci": "npm run build && npm run cov",
-
     "purge": "npm run clean && rm -rf node_modules",
     "clean": "lerna clean --yes; rm -rf ./packages/**/package-lock.json",
     "reset": "npm run purge && npm i && npm run ci",
-
     "publish": "rm -f ./packages/.DS*; sh scripts/publish.sh",
     "beta": "sh scripts/publish.sh --npm-tag pandora2-beta --force-publish=*",
     "canary": "sh scripts/publish.sh --canary",
-
     "authors": "git log --format='%aN <%aE>' | sort -u > AUTHORS",
-
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs",
     "docs:deploy": "node ./scripts/deploy_doc.js"
-
   },
   "keywords": [
     "container",

--- a/packages/component-actuator-server/src/ActuatorRestServer.ts
+++ b/packages/component-actuator-server/src/ActuatorRestServer.ts
@@ -19,19 +19,13 @@ export class ActuatorRestServer {
     const httpConfig = this.config.http;
     const app = this.app;
 
-    app.use((ctx, next) => {
-      if (ctx.headers) {
-        const encoding = ctx.headers['content-encoding'];
-        if (encoding) {
-          if (ActuatorRestServer.supportEncoding.indexOf(encoding) < 0) {
-            ctx.headers['content-encoding'] = ActuatorRestServer.defaultEncoding;
-          }
-        }
-      }
-      return next();
-    });
-
-    app.use(bodyParser({ enableTypes: ['json', 'form', 'text'] }));
+    if (httpConfig.middlewares) {
+      httpConfig.middlewares.forEach((middleware) => {
+        app.use(middleware);
+      });
+    } else {
+      app.use(bodyParser());
+    }
 
     let homeRouter = new Router();
     homeRouter.get('/', async (ctx) => {

--- a/packages/component-actuator-server/src/ActuatorRestServer.ts
+++ b/packages/component-actuator-server/src/ActuatorRestServer.ts
@@ -3,9 +3,6 @@ import bodyParser = require('koa-bodyparser');
 import Router = require('koa-router');
 
 export class ActuatorRestServer {
-  static supportEncoding = ['gzip', 'deflate', 'identity'];
-  static defaultEncoding = 'identity';
-
   server;
   app: KOA;
   config: any;

--- a/packages/component-actuator-server/test/ActuatorRestServer.test.ts
+++ b/packages/component-actuator-server/test/ActuatorRestServer.test.ts
@@ -55,6 +55,26 @@ describe('ActuatorRestServer', function () {
     });
   });
 
+  it('should post unsupport encoding be ok', async () => {
+    const encodingEndPoint: IEndPoint = {
+      prefix: '/encoding',
+      route(router) {
+        router.post('/', (ctx) => {
+          console.log('ctx.request.body: ', ctx.request.body);
+          ctx.ok(ctx.request.body);
+        });
+      }
+    };
+    endPointManager.register(encodingEndPoint);
+    const result = await request(actuatorRestServer.server)
+      .post('/encoding/')
+      .send('encoding')
+      .set('Content-Type', 'text/plain; charset=ISO-8859-1')
+      .set('Content-Encoding', 'UTF-8')
+      .expect(200);
+    expect(result.body.data).to.equal('encoding');
+  });
+
   it('should endPoint fail result be ok', async () => {
     const testEndPoint: IEndPoint = {
       prefix: '/test2',

--- a/packages/component-file-logger-service/src/FileLoggerManager.ts
+++ b/packages/component-file-logger-service/src/FileLoggerManager.ts
@@ -84,6 +84,16 @@ export class FileLoggerManager {
     }
   }
 
+  private nonBlocking(logger): void {
+    const fileTransport = logger.get('file');
+    if (fileTransport) {
+      const timer = fileTransport._timer;
+      if (timer) {
+        timer.unref();
+      }
+    }
+  }
+
   public createLogger(loggerName, loggerConfig: LoggerConfig): ILogger {
 
     loggerConfig = Object.assign({}, DEFAULT_LOGGER_CONFIG, loggerConfig);
@@ -98,6 +108,8 @@ export class FileLoggerManager {
       consoleLevel: loggerConfig.stdoutLevel,
       eol: loggerConfig.eol
     });
+    // make logger non blocking
+    this.nonBlocking(newLogger);
     this.loggerMap.set(uuid, newLogger);
     this.sendRotationStrategy({
       uuid: uuid,

--- a/packages/component-reporter-manager/src/oscillator/MetricsOscillator.ts
+++ b/packages/component-reporter-manager/src/oscillator/MetricsOscillator.ts
@@ -38,6 +38,8 @@ export class MetricsOscillator extends EventEmitter {
           debug('collect error', err);
         });
       }, interval);
+      // non blocking
+      this.intervalHandler.unref();
     }
   }
 

--- a/packages/component-trace/src/TraceManager.ts
+++ b/packages/component-trace/src/TraceManager.ts
@@ -170,6 +170,8 @@ export class TraceManager extends EventEmitter {
           this.logger.error('[TraceManager] interval dump data error. ', error);
         }
       }, this.interval);
+      // non blocking
+      this.intervalId.unref();
     }
   }
 

--- a/packages/pandora/src/application/spawnWrapper.ts
+++ b/packages/pandora/src/application/spawnWrapper.ts
@@ -36,6 +36,8 @@ async function main () {
   }
 
   // unref all active handles
+  // after node.js v11, Timer objects no longer show up in process._getActiveHandles()
+  // see: https://github.com/nodejs/node/issues/25806
   try {
     for(const handler of (<any> process)._getActiveHandles()) {
       try {


### PR DESCRIPTION
some request from java with wrong encoding will failed.
![image](https://user-images.githubusercontent.com/1409643/74499946-4bf33800-4f20-11ea-95cd-bdec8c07f4c4.png)

+ **Feat**: Add custom middlewares config for actuator-server
+ **Fix**: Fix `packages/pandora/test/bug/unref.test.ts`, after node.js v11, Timer objects no longer show up in `process._getActiveHandles()`, see: https://github.com/nodejs/node/issues/25806. If use `async-hooks`, can unref all `setInterval` without invasion
